### PR TITLE
Bump qs to 6.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "webpack": "^5.94.0"
   },
   "dependencies": {
-    "qs": "^6.14.1",
+    "qs": "^6.15.2",
     "whatwg-fetch": "^3.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3630,7 +3630,14 @@ qjobs@^1.2.0:
   resolved "https://registry.yarnpkg.com/qjobs/-/qjobs-1.2.0.tgz#c45e9c61800bd087ef88d7e256423bdd49e5d071"
   integrity sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==
 
-qs@^6.14.1, qs@~6.14.0:
+qs@^6.15.2:
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
+  dependencies:
+    side-channel "^1.1.0"
+
+qs@~6.14.0:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.1.tgz#a41d85b9d3902f31d27861790506294881871159"
   integrity sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==


### PR DESCRIPTION
Bumps the direct `qs` dependency from 6.14.1 to 6.15.2 to resolve the medium severity Dependabot alert ([dependabot-151](https://github.com/PipelineDeals/pipeline-js-api-client/security/dependabot/151)).

Closes #39

Note: a dev-only transitive `qs@6.14.1` remains via `body-parser` (karma's dev server), which pins `qs ~6.14.0`. The runtime dependency is now on 6.15.2.

All 8 karma tests pass locally.