### PR TITLE
Add committed Claude Code agent config (permissions + sensitive-file hook)

### DIFF
--- a/.claude/hooks/protect-sensitive-files.sh
+++ b/.claude/hooks/protect-sensitive-files.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# protect-sensitive-files.sh
+#
+# PreToolUse hook — blocks edits to sensitive files.
+# Receives JSON on stdin with tool_input.file_path.
+# Exit 0 = allow, Exit 2 = block (stderr shown to Claude).
+
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+basename=$(basename "$file_path")
+dirpath=$(dirname "$file_path")
+
+# Block sensitive files
+case "$basename" in
+  .env|.env.*|.env.local|.env.production|.env.staging)
+    echo "BLOCKED: Will not edit environment file: $file_path" >&2
+    exit 2
+    ;;
+  credentials.json|secrets.json|secrets.yml|secrets.yaml)
+    echo "BLOCKED: Will not edit credentials file: $file_path" >&2
+    exit 2
+    ;;
+  *.pem|*.key|*.p12|*.pfx|id_rsa|id_ed25519)
+    echo "BLOCKED: Will not edit key/certificate file: $file_path" >&2
+    exit 2
+    ;;
+  master.key|credentials.yml.enc)
+    echo "BLOCKED: Will not edit Rails encrypted credentials: $file_path" >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,12 @@
       "Bash(git log:*)",
       "Bash(git fetch:*)",
       "Bash(gh pr view:*)",
-      "Bash(gh pr list:*)"
+      "Bash(gh pr list:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr edit:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh issue comment:*)"
     ],
     "deny": [
       "Read(./.env)",
@@ -22,7 +27,6 @@
       "Edit(./.env.*)"
     ],
     "ask": [
-      "Bash(git push:*)",
       "Bash(gh pr merge:*)"
     ]
   },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,42 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(yarn test)",
+      "Bash(yarn lint:*)",
+      "Bash(yarn build:*)",
+      "Bash(git status)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git fetch:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Read(**/*.p12)",
+      "Read(**/id_rsa)",
+      "Edit(./.env)",
+      "Edit(./.env.*)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(gh pr merge:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/protect-sensitive-files.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This commits a team-shared Claude Code agent configuration layer for this repo:

- `.claude/settings.json` — permission rules that apply to anyone running Claude Code here:
  - **deny**: reading or editing secret material (`.env*`, `*.pem`, `*.key`, `*.p12`, `id_rsa`)
  - **ask**: high-risk actions require explicit human confirmation (`git push`, `gh pr merge`)
  - **allow**: this repo's own test/lint/build commands plus read-only `git`/`gh` commands, so routine agent work does not prompt
- `.claude/hooks/protect-sensitive-files.sh` — a `PreToolUse` hook that blocks agent edits to env files, credentials, and key/certificate material as a second layer of defense, independent of the permission rules

Part of the agentic-readiness work rolling committed agent config across Pipeline CRM repos.

Repo-specific notes: allow rules cover `yarn test`, `yarn lint`, and `yarn build` (Yarn, per the committed `yarn.lock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Update: agents may push branches and create/edit PRs without prompts; merge and migrations remain human-gated (and branch protection requires human approval regardless).