### PR TITLE
Run Claude review automatically on every PR

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,76 @@
+# Claude PR review — runs automatically when a PR is opened or marked ready
+# for review (drafts excluded), and on @claude mentions in PR comments.
+#
+# Requires: ANTHROPIC_API_KEY available to the repo (org-level secret).
+name: Claude Code
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  actions: read
+  id-token: write
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Acknowledge comment
+        # Only comment events carry github.event.comment; skip on pull_request
+        if: github.event_name != 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'pull_request_review_comment') {
+              await github.rest.reactions.createForPullRequestReviewComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes'
+              });
+            } else {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes'
+              });
+            }
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review this PR for a Pipeline CRM JavaScript project. Focus on:
+            - Bugs or logic errors
+            - XSS and injection risks: unsanitized user or API data reaching the
+              DOM, templates, or dynamically built queries/commands
+            - API token and credential handling — no secrets in code, logs, or
+              anything that ships in a client bundle
+            - Bundle size and dependency risk: new dependencies should be
+              justified, sensibly pinned, and free of supply-chain red flags
+            - Convention violations per this repo's CLAUDE.md, if present
+
+            You have full repo access. Read any files you need to verify your findings.
+            Only flag issues introduced by this PR, not pre-existing patterns.
+            Be concise. If the code is sound, say so in 2-3 sentences — do not
+            manufacture findings. Reserve detailed comments for real issues.
+          track_progress: true
+          include_fix_links: true
+          claude_args: "--max-turns 12 --max-budget-usd 0.75"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -73,4 +73,4 @@ jobs:
             manufacture findings. Reserve detailed comments for real issues.
           track_progress: true
           include_fix_links: true
-          claude_args: "--max-turns 12 --max-budget-usd 0.75"
+          claude_args: "--model claude-sonnet-5 --max-turns 12 --max-budget-usd 0.75"


### PR DESCRIPTION
Adds `.github/workflows/claude-review.yml` so Claude Code reviews run automatically on every PR.

- Claude reviews every PR automatically when it is **opened** or marked **ready for review**. Draft PRs are excluded.
- Mention `@claude` in a PR comment or review comment to trigger a re-review or ask follow-up questions.
- Uses the org-level `ANTHROPIC_API_KEY` secret (already visible to this repo) — no repo-level secret setup needed.
- The review prompt is tailored to this repo: a JS API client (XSS/injection, token handling, dependency risk).
- Budget-capped per run: `--max-turns 12 --max-budget-usd 0.75`, 15-minute job timeout.
- If the code is sound, Claude says so briefly rather than manufacturing findings.

Part of the agentic-readiness work rolling this out across Pipeline CRM repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Update: review runs pinned to Sonnet — cheaper per run, and the reviewing model differs from the model that authors most changes.