### PR TITLE
Bump ws to 8.21.1 to fix GHSA-96hv-2xvq-fx4p (memory-exhaustion DoS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
   "dependencies": {
     "qs": "^6.15.2",
     "whatwg-fetch": "^3.6.0"
+  },
+  "resolutions": {
+    "ws": "^8.21.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4580,10 +4580,10 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-ws@~8.17.1:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
-  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
+ws@^8.21.0, ws@~8.17.1:
+  version "8.21.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.1.tgz#045650cd4b1207809e7547146223c3814a9af586"
+  integrity sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
Fixes #55 (Dependabot alert [GHSA-96hv-2xvq-fx4p](https://github.com/PipelineDeals/pipeline-js-api-client/security/dependabot/154), high severity, due 2026-07-21).

## Problem

`ws@8.17.1` — a dev-only transitive dependency (`karma > socket.io > engine.io`) — is vulnerable to a memory-exhaustion DoS from tiny fragments and data chunks. The 8.x line is patched in **8.21.0**, but `engine.io` pins `ws@~8.17.1`, so a plain lockfile refresh can never reach the fixed version.

## Fix

Added a Yarn 1 `resolutions` override forcing `ws` to `^8.21.0`; the lockfile now resolves a single `ws@8.21.1` entry for all requesters.

## Verification

- `yarn.lock` contains only `ws@8.21.1` (`yarn why ws` confirms no other copies)
- `yarn test`: 8/8 specs pass in ChromeHeadless — karma's socket.io connection runs over `ws`, so the override is exercised end-to-end

No runtime/production dependency is affected (`ws` is test-infrastructure only), so no `lib/` rebuild or version bump is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)