### PR TITLE
Bump fast-uri 3.1.2 → 3.1.5 (host confusion — GHSA-v2hh-gcrm-f6hx / GHSA-4c8g-83qw-93j6)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2494,9 +2494,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
## Why

High: two fast-uri host-confusion advisories (issue #61, due 2026-08-24 — soonest of the assigned vulns):
- **GHSA-v2hh-gcrm-f6hx** — host confusion via literal backslash authority delimiter
- **GHSA-4c8g-83qw-93j6** — host confusion via failed IDN canonicalization

## Fix

fast-uri is a **transitive** dependency (range `^3.0.1`), so this is a lockfile-only bump — re-resolved to the latest 3.x (**3.1.5**), clearing both advisories (patched 3.1.3 / 3.1.4). **package.json is untouched** (fast-uri stays transitive).

Closes #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)