### PR TITLE
Serialize request bodies in the fetcher

### DIFF
--- a/spec/src/IphoneAuth_spec.js
+++ b/spec/src/IphoneAuth_spec.js
@@ -1,0 +1,29 @@
+/* global sinon */
+
+import IphoneAuth from '../../src/IphoneAuth'
+import { jsonOk } from '../helpers'
+
+window.Promise = Promise
+
+describe('IphoneAuth', () => {
+  beforeEach(() => {
+    sinon.stub(window, 'fetch')
+  })
+
+  afterEach(() => {
+    window.fetch.restore()
+  })
+
+  it('posts the credentials as JSON and returns the user', (done) => {
+    window.fetch.returns(jsonOk({ user: { id: 123 } }))
+
+    IphoneAuth('someone', 'secret')
+      .catch(done)
+      .then(user => {
+        expect(window.fetch.getCall(0).args[0]).toEqual('https://api.pipelinedeals.com/api/v3/iphone_auths')
+        expect(window.fetch.getCall(0).args[1].body).toEqual('{"email_or_username":"someone","password":"secret"}')
+        expect(user).toEqual({ id: 123 })
+        done()
+      })
+  })
+})

--- a/spec/src/Requester_spec.js
+++ b/spec/src/Requester_spec.js
@@ -30,6 +30,49 @@ describe('Requester', () => {
           done()
         })
     })
+
+    it('sends the body as JSON', (done) => {
+      window.fetch.returns(jsonOk({ id: 123 }))
+
+      let client = new Requester('http://pld.com/api/v3', {apiKey: '1234'})
+
+      client.post('/notes.json', { body: { note: { content: 'hi' } } })
+        .catch(done)
+        .then(() => {
+          expect(window.fetch.getCall(0).args[1].body).toEqual('{"note":{"content":"hi"}}')
+          done()
+        })
+    })
+  })
+
+  describe('#put', () => {
+    it('sends the body as JSON', (done) => {
+      window.fetch.returns(jsonOk({ id: 123 }))
+
+      let client = new Requester('http://pld.com/api/v3', {apiKey: '1234'})
+
+      client.put('/notes/1.json', { body: { note: { content: 'hi' } } })
+        .catch(done)
+        .then(() => {
+          expect(window.fetch.getCall(0).args[1].body).toEqual('{"note":{"content":"hi"}}')
+          done()
+        })
+    })
+  })
+
+  describe('#delete', () => {
+    it('sends the body as JSON', (done) => {
+      window.fetch.returns(jsonOk({ id: 123 }))
+
+      let client = new Requester('http://pld.com/api/v3', {apiKey: '1234'})
+
+      client.delete('/notes.json', { body: { ids: [1, 2] } })
+        .catch(done)
+        .then(() => {
+          expect(window.fetch.getCall(0).args[1].body).toEqual('{"ids":[1,2]}')
+          done()
+        })
+    })
   })
 
   describe('#request', () => {

--- a/spec/src/fetcher_spec.js
+++ b/spec/src/fetcher_spec.js
@@ -77,6 +77,52 @@ describe('fetcher', () => {
     }))
   })
 
+  describe('body serialization', () => {
+    const bodyOf = () => window.fetch.getCall(0).args[1].body
+
+    it('serializes an Object body as JSON', sinon.test(async () => {
+      window.fetch.returns(jsonResponse({ body: {} }))
+
+      await fetcher('/fetcher', { method: 'POST', body: { note: { content: 'hi' } } })
+
+      chai.expect(bodyOf()).to.equal('{"note":{"content":"hi"}}')
+    }))
+
+    it('serializes an Array body as JSON', sinon.test(async () => {
+      window.fetch.returns(jsonResponse({ body: {} }))
+
+      await fetcher('/fetcher', { method: 'POST', body: [1, 2] })
+
+      chai.expect(bodyOf()).to.equal('[1,2]')
+    }))
+
+    it('leaves an already serialized body alone', sinon.test(async () => {
+      window.fetch.returns(jsonResponse({ body: {} }))
+
+      await fetcher('/fetcher', { method: 'POST', body: '{"note":{"content":"hi"}}' })
+
+      chai.expect(bodyOf()).to.equal('{"note":{"content":"hi"}}')
+    }))
+
+    it('leaves a FormData body alone', sinon.test(async () => {
+      window.fetch.returns(jsonResponse({ body: {} }))
+
+      const form = new window.FormData()
+
+      await fetcher('/fetcher', { method: 'POST', body: form })
+
+      chai.expect(bodyOf()).to.equal(form)
+    }))
+
+    it('sends no body when none was given', sinon.test(async () => {
+      window.fetch.returns(jsonResponse({ body: {} }))
+
+      await fetcher('/fetcher')
+
+      chai.expect(window.fetch.getCall(0).args[1]).to.not.have.property('body')
+    }))
+  })
+
   describe('response handling', () => {
     it('throws a ResponseError for error status', sinon.test(async () => {
       window.fetch.withArgs('/fetcher', {

--- a/src/IphoneAuth.js
+++ b/src/IphoneAuth.js
@@ -8,7 +8,7 @@ export default function IphoneAuth (username, password, apiBase = 'https://api.p
   }
 
   return fetcher(path, {
-    body: JSON.stringify(body),
+    body,
     method: 'POST'
   }).then(json => { return json.user })
 }

--- a/src/Requester.js
+++ b/src/Requester.js
@@ -11,11 +11,11 @@ export default class Requester {
   }
 
   post (path, { body = {}, ...options } = {}) {
-    return fetcher(this.__path(path), { auth: this.__auth, method: 'POST', body: JSON.stringify(body), ...options })
+    return fetcher(this.__path(path), { auth: this.__auth, method: 'POST', body, ...options })
   }
 
   put (path, { body = {}, ...options } = {}) {
-    return fetcher(this.__path(path), { auth: this.__auth, method: 'PUT', body: JSON.stringify(body), ...options })
+    return fetcher(this.__path(path), { auth: this.__auth, method: 'PUT', body, ...options })
   }
 
   request (path, options = {}) {

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -12,8 +12,14 @@ const handleResponse = response => {
 
 const param = query => qs.stringify(query, { arrayFormat: 'brackets' })
 
+const isJSONable = body =>
+  Array.isArray(body) ||
+  Object.prototype.toString.call(body) === '[object Object]'
+
+const serialize = body => isJSONable(body) ? JSON.stringify(body) : body
+
 export const fetcher = (path, options = {}) => {
-  const { auth, headers, query, ...rest } = options
+  const { auth, body, headers, query, ...rest } = options
   const fetchUrl = url(path, { ...query, ...auth })
 
   return fetch(fetchUrl, {
@@ -23,6 +29,7 @@ export const fetcher = (path, options = {}) => {
       'Content-Type': 'application/json',
       ...headers
     },
+    ...(body === undefined ? {} : { body: serialize(body) }),
     ...rest
   })
     .then(handleResponse)


### PR DESCRIPTION
This PR proposes moving JSON body serialization into `fetcher`, so an Object body is encoded once for every verb instead of only on `post` and `put` (Fixes #8). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/330. You can sign in with your GitHub ID to claim ownership of the project.

## The defect

`fetcher` never touches `body`, so serialization lives in each caller: `Requester#post` and `Requester#put` call `JSON.stringify` by hand, `IphoneAuth` does its own, and `Requester#delete` and `Requester#request` do not — they hand the Object straight to `fetch`, which stringifies it as `[object Object]` and sends that under `Content-Type: application/json`. So `client.delete('/notes.json', { body: { ids: [1, 2] } })` reaches the server as a five-word literal rather than JSON, and the same is true of any body passed to `request`.

Reproduced on `master` at 4b20f22 by adding the specs in this PR and leaving `src/` untouched:

```
$ yarn test
Requester #delete sends the body as JSON FAILED
        Expected Object({ ids: [ 1, 2 ] }) to equal '{"ids":[1,2]}'.
fetcher body serialization serializes an Object body as JSON FAILED
        AssertionError: expected { note: { content: 'hi' } } to equal '{"note":{"content":"hi"}}'
fetcher body serialization serializes an Array body as JSON FAILED
        AssertionError: expected [ 1, 2 ] to equal '[1,2]'
Chrome Headless: Executed 16 of 16 (3 FAILED)
```

## The change

`fetcher` now pulls `body` out of its options and serializes it when it is a plain Object or an Array, leaving everything else exactly as given; `Requester#post`/`#put` and `IphoneAuth` drop their own `JSON.stringify`, and `delete`/`request` get the behavior for free. Bodies are still opt-in: when no `body` is passed, the options object handed to `fetch` has no `body` key, as before.

Compatibility, since this is the shared path for every request:

- Object bodies through `post`/`put` serialize to the identical string as today — the two `#post`/`#put` control specs pass unchanged before and after this commit.
- An already-serialized String body now passes through untouched instead of being double-encoded, which is the only intentional behavior change here.
- `FormData` (and anything else that is not a plain Object or Array) is passed to `fetch` by identity, so multipart uploads keep working.

## Verification

`yarn test` (Karma/Jasmine in headless Chrome, the same command CI runs) on a clean `master` is green at 8 specs, and green at 17 with this branch — the three failures quoted above flip to passing and nothing else moves:

```
$ yarn test        # clean master
Chrome Headless: Executed 8 of 8 SUCCESS

$ yarn test        # this branch
Chrome Headless: Executed 17 of 17 SUCCESS
```

`yarn lint` is clean. New coverage: Object, Array, pre-serialized String, `FormData` and no-body cases on `fetcher`; body assertions on `Requester#post`, `#put` and `#delete`; and a first spec for `IphoneAuth`, which had none and whose request body is asserted to be byte-identical to what it sent before.

One judgment call worth flagging: I left the committed `lib/` output out of this diff. Rebuilding it with the pinned toolchain rewrites all twenty files (quote style, the `exports.default` shape, helper inlining) because `lib/` was last built before the module bump, which would bury a nine-line source change under ~850 lines of codegen churn. Say the word and I will add the regenerated output, or fold it into your release build step.

## How this was managed

The board at https://eastagiletracker.com/projects/330 was imported from this repo's own issues and pull requests (62 stories, 8 labels), and this work was tracked on the story it belongs to: https://eastagiletracker.com/projects/330/stories/213565

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
