### PR TITLE
#51 Bump js-yaml 3.14.2 -> 3.15.1 (GHSA-h67p-54hq-rp68)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3087,9 +3087,9 @@ jest-worker@^28.0.2:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
+  integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
Closes #51

## What

Lockfile-only bump of `js-yaml` from 3.14.2 to 3.15.1, clearing the one open Dependabot alert on this repo.

| Advisory | Severity | Due | Patched in |
|---|---|---|---|
| [GHSA-h67p-54hq-rp68](https://github.com/PipelineDeals/pipeline-js-api-client/security/dependabot/157) — quadratic-complexity DoS in merge key handling via repeated aliases | medium | 2026-09-06 | 3.15.0 |

## Why 3.15.1 and not 3.15.0

3.15.1 is the latest 3.x and additionally carries the fix for GHSA-5p4m-2wfm-xmqj (quadratic CPU consumption in `!!omap` resolution), which is already filed as an alert against the 3.x line in `pipeline_deals`. Landing 3.15.1 now clears the successor advisory in the same change instead of taking two round trips.

## Scope

`js-yaml` is a **transitive devDependency** — pulled in by eslint 7 via `@eslint/eslintrc` and `@humanwhocodes/config-array`, both declaring `js-yaml "^3.13.1"`. 3.15.1 sits inside that range, so this is a pure `yarn.lock` change:

- no `package.json` change
- no `resolutions` override
- the committed `lib/` build output is untouched — the dependency is dev-only and never enters the babel/webpack output, so consumers pinning this package by git tag see no change

## Verification

- `yarn install --frozen-lockfile` — the exact CI gate — resolves cleanly
- `node -e "require('./node_modules/js-yaml/package.json').version"` reports `3.15.1`
- `yarn lint` — clean (this exercises eslint, the actual consumer of js-yaml)
- `yarn test` — 8/8 passing in ChromeHeadless
